### PR TITLE
refactor: Update phrase interpolation implementation

### DIFF
--- a/source/Format.cpp
+++ b/source/Format.cpp
@@ -232,6 +232,35 @@ string Format::Replace(const string &source, const map<string, string> keys)
 
 
 
+void Format::ReplaceAll(string &text, const string &target, const string &replacement)
+{
+	// If the searched string is an empty string, do nothing.
+	if(target.empty())
+		return;
+	
+	string newString;
+	newString.reserve(text.length());
+	
+	// Index at which to begin searching for the target string.
+	size_t start = 0;
+	size_t matchLength = target.length();
+	// Index at which the target string was found.
+	size_t findPos = string::npos;
+	while((findPos = text.find(target, start)) != string::npos)
+	{
+		newString.append(text, start, findPos - start);
+		newString += replacement;
+		start = findPos + matchLength;
+	}
+	
+	// Add the remaining text.
+	newString += text.substr(start);
+	
+	text.swap(newString);
+}
+
+
+
 string Format::Capitalize(const string &str)
 {
 	string result = str;

--- a/source/Format.h
+++ b/source/Format.h
@@ -38,6 +38,8 @@ public:
 	// Replace a set of "keys," which must be strings in the form "<name>", with
 	// a new set of strings, and return the result.
 	static std::string Replace(const std::string &source, const std::map<std::string, std::string> keys);
+	// Replace all occurences of "target" with "replacement" in-place.
+	static void ReplaceAll(std::string &text, const std::string &target, const std::string &replacement);
 	
 	// Convert a string to title caps or to lower case.
 	static std::string Capitalize(const std::string &str);

--- a/source/Phrase.cpp
+++ b/source/Phrase.cpp
@@ -128,6 +128,13 @@ Phrase::Choice::Choice(const DataNode &node, bool isPhraseName)
 	
 	// This node is a text string that may contain an interpolation request.
 	const string &entry = node.Token(0);
+	if(entry.empty())
+	{
+		// A blank choice was desired.
+		emplace_back();
+		return;
+	}
+	
 	size_t start = 0;
 	while(start < entry.size())
 	{

--- a/source/Phrase.cpp
+++ b/source/Phrase.cpp
@@ -72,6 +72,13 @@ void Phrase::Load(const DataNode &node)
 {
 	// Set the name of this phrase, so we know it has been loaded.
 	name = node.Size() >= 2 ? node.Token(1) : "Unnamed Phrase";
+	// To avoid a possible parsing ambiguity, the interpolation delimiters
+	// may not be used in a Phrase's name.
+	if(name.find("${") != string::npos || name.find('}') != string::npos)
+	{
+		node.PrintTrace("Phrase names may not contain '${' or '}':");
+		return;
+	}
 	
 	sentences.emplace_back();
 	sentences.back().Load(node, this);

--- a/source/Phrase.cpp
+++ b/source/Phrase.cpp
@@ -13,40 +13,11 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Phrase.h"
 
 #include "DataNode.h"
+#include "Format.h"
 #include "GameData.h"
 #include "Random.h"
 
 using namespace std;
-
-namespace {
-	// Replaces all occurrences of the target string with the given string in-place.
-	void ReplaceAll(string &text, const string &target, const string &replacement)
-	{
-		// If the searched string is an empty string, do nothing.
-		if(target.empty())
-			return;
-		
-		string newString;
-		newString.reserve(text.size());
-		
-		// Index at which to begin searching for the target string.
-		size_t start = 0;
-		size_t matchLength = target.size(); 
-		// Index at which the target string was found.
-		size_t findPos = string::npos;
-		while((findPos = text.find(target, start)) != string::npos)
-		{
-			newString.append(text, start, findPos - start);
-			newString += replacement;
-			start = findPos + matchLength;
-		}
-		
-		// Add the remaining text.
-		newString += text.substr(start);
-		
-		text.swap(newString);
-	}
-}
 
 
 
@@ -96,9 +67,9 @@ string Phrase::Get() const
 			for(const auto &element : choice)
 				result += element.second ? element.second->Get() : element.first;
 		}
-		else if(!part.replaceRules.empty())
-			for(const auto &f : part.replaceRules)
-				f(result);
+		else if(!part.replacements.empty())
+			for(const auto &pair : part.replacements)
+				Format::ReplaceAll(result, pair.first, pair.second);
 	}
 	
 	return result;
@@ -147,7 +118,7 @@ Phrase::Choice::Choice(const DataNode &node, bool isPhraseName)
 	}
 	
 	size_t start = 0;
-	while(start < entry.size())
+	while(start < entry.length())
 	{
 		// Determine if there is an interpolation request in this string.
 		size_t left = entry.find("${", start);
@@ -202,17 +173,8 @@ void Phrase::Sentence::Load(const DataNode &node, const Phrase *parent)
 			for(const DataNode &grand : child)
 				part.choices.emplace_back(grand, true);
 		else if(child.Token(0) == "replace")
-		{
 			for(const DataNode &grand : child)
-			{
-				const string oldStr = grand.Token(0);
-				const string newStr = grand.Size() >= 2 ? grand.Token(1) : "";
-				part.replaceRules.emplace_back([oldStr, newStr](string &s) -> void
-				{
-					ReplaceAll(s, oldStr, newStr);
-				});
-			}
-		}
+				part.replacements.emplace_back(grand.Token(0), grand.Size() >= 2 ? grand.Token(1) : string{});
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");
 		
@@ -227,7 +189,7 @@ void Phrase::Sentence::Load(const DataNode &node, const Phrase *parent)
 				}
 		
 		// If no words, phrases, or replaces were given, discard this part of the phrase.
-		if(part.choices.empty() && part.replaceRules.empty())
+		if(part.choices.empty() && part.replacements.empty())
 			pop_back();
 	}
 }

--- a/source/Phrase.h
+++ b/source/Phrase.h
@@ -57,8 +57,9 @@ private:
 	public:
 		// Sources of text, either literal or via phrase invocation.
 		std::vector<Choice> choices;
-		// Rules for updating the generated text.
-		std::vector<std::function<void(std::string&)>> replaceRules;
+		// Character sequences that should be replaced, e.g. "llo"->"y"
+		// would transfrom "Hello hello" into "Hey hey"
+		std::vector<std::pair<std::string, std::string>> replacements;
 	};
 	
 	

--- a/source/Phrase.h
+++ b/source/Phrase.h
@@ -25,6 +25,7 @@ class DataNode;
 // Class representing a set of rules for generating text strings from words.
 class Phrase {
 public:
+	// Parse the given node into a new branch associated with this phrase.
 	void Load(const DataNode &node);
 	
 	const std::string &Name() const;
@@ -32,27 +33,28 @@ public:
 	
 	
 private:
-	friend class Sentense;
 	bool ReferencesPhrase(const Phrase *phrase) const;
 	
 	
 public:
 	// Option represents a child node in a "word" or "phrase" node.
-	using Option = std::vector<std::pair<std::string, const Phrase*>>;
+	using Option = std::vector<std::pair<std::string, const Phrase *>>;
 	
 	
 private:
-	// Part represents a "word", "phrase", or "replace" in a phrase node.
+	// A Part represents a the content contained by a "word", "phrase", or "replace" child node.
 	class Part {
 	public:
+		// Sources of text, either literal or via phrase invocation.
 		std::vector<Option> options;
+		// Rules for updating the generated text.
 		std::vector<std::function<std::string(const std::string&)>> replaceRules;
 	};
 	
-	// Sentense represents a phrase node.
-	class Sentense {
+	// Sentence represents a phrase node.
+	class Sentence {
 	public:
-		void Load(const DataNode &node, const Phrase* parent);
+		void Load(const DataNode &node, const Phrase *parent);
 		
 		std::vector<Part> parts;
 	};
@@ -61,7 +63,7 @@ private:
 private:
 	std::string name;
 	// Each time this phrase is defined, a new sentence is created.
-	std::vector<Sentense> sentenses;
+	std::vector<Sentence> sentences;
 };
 
 

--- a/source/Phrase.h
+++ b/source/Phrase.h
@@ -58,7 +58,7 @@ private:
 		// Sources of text, either literal or via phrase invocation.
 		std::vector<Choice> choices;
 		// Rules for updating the generated text.
-		std::vector<std::function<std::string(const std::string&)>> replaceRules;
+		std::vector<std::function<void(std::string&)>> replaceRules;
 	};
 	
 	

--- a/source/Phrase.h
+++ b/source/Phrase.h
@@ -36,17 +36,27 @@ private:
 	bool ReferencesPhrase(const Phrase *phrase) const;
 	
 	
-public:
-	// Option represents a child node in a "word" or "phrase" node.
-	using Option = std::vector<std::pair<std::string, const Phrase *>>;
-	
-	
 private:
+	// A Choice represents one entry in a Phrase definition's "word" or "phrase" child
+	// node. If from a "word" node, a Choice may be pure text or contain embedded phrase
+	// references, e.g. `"I'm ${pirate} and I like '${band}' concerts."`.
+	class Choice : private std::vector<std::pair<std::string, const Phrase *>> {
+	public:
+		// Create a choice from a grandchild DataNode.
+		Choice(const DataNode &node, bool isPhraseName = false);
+		
+		// Enable empty checks and iteration:
+		using std::vector<std::pair<std::string, const Phrase *>>::empty;
+		using std::vector<std::pair<std::string, const Phrase *>>::begin;
+		using std::vector<std::pair<std::string, const Phrase *>>::end;
+	};
+	
+	
 	// A Part represents a the content contained by a "word", "phrase", or "replace" child node.
 	class Part {
 	public:
 		// Sources of text, either literal or via phrase invocation.
-		std::vector<Option> options;
+		std::vector<Choice> choices;
 		// Rules for updating the generated text.
 		std::vector<std::function<std::string(const std::string&)>> replaceRules;
 	};
@@ -58,7 +68,7 @@ private:
 		Sentence(const DataNode &node, const Phrase *parent);
 		void Load(const DataNode &node, const Phrase *parent);
 		
-		// Expose certain functions from the underlying vector:
+		// Enable empty checks and iteration:
 		using std::vector<Part>::empty;
 		using std::vector<Part>::begin;
 		using std::vector<Part>::end;

--- a/source/Phrase.h
+++ b/source/Phrase.h
@@ -51,12 +51,17 @@ private:
 		std::vector<std::function<std::string(const std::string&)>> replaceRules;
 	};
 	
-	// Sentence represents a phrase node.
-	class Sentence {
+	
+	// An individual definition associated with a Phrase name.
+	class Sentence : private std::vector<Part> {
 	public:
+		Sentence(const DataNode &node, const Phrase *parent);
 		void Load(const DataNode &node, const Phrase *parent);
 		
-		std::vector<Part> parts;
+		// Expose certain functions from the underlying vector:
+		using std::vector<Part>::empty;
+		using std::vector<Part>::begin;
+		using std::vector<Part>::end;
 	};
 	
 	


### PR DESCRIPTION
I updated some methods and moved things around a bit

Notable additions:
 - empty choices are allowed
 - phrase names cannot contain ${ or }
 - moved Replace to Format as ReplaceAll

Please review/merge at your discretion; I am interested in your feedback if you have any.